### PR TITLE
`rails g`コマンドの際にいらないファイルが生成されないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,11 @@ module FlowSample
     # config.i18n.default_locale = :de
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
+
     config.active_record.raise_in_transactional_callbacks = true
   end
 end


### PR DESCRIPTION
#1
config/apprication.rbに不要ファイルを作成しない設定を追加